### PR TITLE
fix: change protocol from relative to https

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,6 @@
 export default {
   api: {
-    url: '//api.linximpulse.com/engage/wishlist/v3',
+    url: 'https://api.linximpulse.com/engage/wishlist/v3',
   },
   cookieName: {
     deviceId: 'chaordic_browserId',


### PR DESCRIPTION
Ao acessar a página de busca via http o sdk usa no config protocolo relativo, logo a requisição será feita em http. Porém quando o kong redireciona de http para https ele perde os headers e falha a requisição.