### PR TITLE
refactor: update commons-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -757,8 +757,9 @@
       }
     },
     "@linx-impulse/commons-js": {
-      "version": "git+ssh://git@github.com/chaordic/commons-js.git#43cfa89367f9eb822f4dfadf52e3d990ab2111d3",
-      "from": "git+ssh://git@github.com/chaordic/commons-js.git"
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@linx-impulse/commons-js/-/commons-js-4.0.2.tgz",
+      "integrity": "sha512-i498S3tbID5tgxwNWZj0L3Z0iUv8Tt0x4gnU3OXPFCXyJS5Q/uy8AAcwofMqMVZGbScVJPZj73Kx8/wvHHta7g=="
     },
     "@sinonjs/commons": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "@linx-impulse/commons-js": "git+ssh://git@github.com:chaordic/commons-js.git"
+    "@linx-impulse/commons-js": "^4.0.2"
   }
 }


### PR DESCRIPTION
Atualiza a versão do commons-js para [4.0.2](https://github.com/chaordic/commons-js/pull/14).