### PR TITLE
fix: get like count endpoint

### DIFF
--- a/src/facades/likes.js
+++ b/src/facades/likes.js
@@ -96,7 +96,7 @@ export default {
     showOnlyAvailable,
   }) => new Promise((resolve, reject) => {
     ajax({
-      url: `${config.api.url}/likes/items/count`,
+      url: `${config.api.url}/likes/count`,
       type: 'GET',
       params: {
         userId,

--- a/test/facades/likes.spec.js
+++ b/test/facades/likes.spec.js
@@ -81,7 +81,7 @@ describe('LikesFacade', function() {
 
       server.respondWith(
         'GET',
-        /\/engage\/wishlist\/v3\/likes\/items\/count/,
+        /\/engage\/wishlist\/v3\/likes\/count/,
         [200, { 'Content-Type': 'application/json' }, JSON.stringify(expectedResponse)],
       );
 


### PR DESCRIPTION
Corrige o endpoint da função getLikeCount que está errado.

Para testar, deployar o tema suite localmente e inserir uma tag `<my-lists-button></my-lists-button>`. O fluxo vai quebrar, para funcionar então usar `npm link` neste repositório e depois `npm link @linx-impulse/engage-wishlist-sdk-js` no diretório `suite-<apiKey>/packages/wishlist`.